### PR TITLE
Add `svelte` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "description": "Use all nerdfont-icons in your Svelte project",
   "main": "components/index.js",
+  "svelte": "components/index.js",
   "type": "module",
   "scripts": {
     "generate": "rm -rf icons; python nerdconvert.py -o es icons --fields iconname viewbox paths",


### PR DESCRIPTION
Hi, nice library. Thanks for publishing it.

I'm having trouble finding any official docs, but I was unable to import the `Icon` component into my Sveltekit project until adding the `svelte` key to the `package.json` of this library.

Here's one example explaining this: https://github.com/sveltejs/kit/issues/1856#issuecomment-876909060